### PR TITLE
Correct detection of 960 transform

### DIFF
--- a/lib/membrane/aac/parser/helper.ex
+++ b/lib/membrane/aac/parser/helper.ex
@@ -155,6 +155,6 @@ defmodule Membrane.AAC.Parser.Helper do
         sample_rate: AAC.sampling_frequency_id_to_sample_rate(sr_index),
         channels: AAC.channel_config_id_to_channels(channel_configuration),
         encapsulation: :none,
-        samples_per_frame: if(frame_length_flag == 1, do: 1024, else: 960)
+        samples_per_frame: if(frame_length_flag == 0, do: 1024, else: 960)
       }
 end

--- a/test/membrane/aac/parser_test.exs
+++ b/test/membrane/aac/parser_test.exs
@@ -76,7 +76,9 @@ defmodule Membrane.AAC.ParserTest do
         # Channel configuration - stereo
         2::4,
         # frame length - 960 samples
-        0b100
+        1::1,
+        0::1,
+        0::1
       >>
     }
 

--- a/test/membrane/aac/parser_test.exs
+++ b/test/membrane/aac/parser_test.exs
@@ -75,9 +75,12 @@ defmodule Membrane.AAC.ParserTest do
         4::4,
         # Channel configuration - stereo
         2::4,
+        # GASpecificConfig
         # frame length - 960 samples
         1::1,
+        # dependsOnCoreCoder
         0::1,
+        # extensionFlag
         0::1
       >>
     }


### PR DESCRIPTION
Fixes incorrect detection of 960 transform in AAC Parser

Related to [RTMP v0.3.0](https://github.com/membraneframework/membrane_rtmp_plugin/pull/9).