### PR TITLE
[MS-561] Better stream format and ADTS header parsing

### DIFF
--- a/lib/membrane/aac/parser.ex
+++ b/lib/membrane/aac/parser.ex
@@ -68,9 +68,18 @@ defmodule Membrane.AAC.Parser do
   end
 
   @impl true
-  def handle_stream_format(:input, %Membrane.RemoteStream{} = _stream_format, _ctx, state) do
+  def handle_stream_format(:input, %Membrane.RemoteStream{} = stream_format, _ctx, state) do
     if state.in_encapsulation == :none and state.out_encapsulation == :ADTS do
-      raise "Not supported parser configuration: in_encapsulation: :none, out_encapsulation: :ADTS"
+      raise """
+        Not supported parser configuration
+        for the stream format: #{inspect(stream_format)}:
+        `in_encapsulation: :none`, `out_encapsulation: :ADTS`
+
+        There is no way to fetch metadata required by ADTS encapsulation,
+        such as number of channels or the sampling frequency, directly
+        from the stream with `in_encapsulation: :none`, neither has the metadata
+        been provided in the stream format.
+      """
     end
 
     {[], state}

--- a/lib/membrane/aac/parser.ex
+++ b/lib/membrane/aac/parser.ex
@@ -74,8 +74,6 @@ defmodule Membrane.AAC.Parser do
     end
 
     {[], state}
-
-    # {[stream_format: {:output, %AAC{encapsulation: state.out_encapsulation, profile: 1, channels: 1, sample_rate: state.samples_per_frame}}], state}
   end
 
   @impl true

--- a/lib/membrane/aac/parser/helper.ex
+++ b/lib/membrane/aac/parser/helper.ex
@@ -8,7 +8,7 @@ defmodule Membrane.AAC.Parser.Helper do
   @header_size 7
   @crc_size 2
 
-  @spec parse_adts(binary, AAC.t(), AAC.Parser.timestamp_t(), %{
+  @spec parse_adts(binary, AAC.t() | nil, AAC.Parser.timestamp_t(), %{
           samples_per_frame: AAC.samples_per_frame_t(),
           encapsulation: AAC.encapsulation_t()
         }) ::
@@ -50,8 +50,9 @@ defmodule Membrane.AAC.Parser.Helper do
 
   defp parse_header(
          <<0xFFF::12, _version::1, 0::2, protection_absent::1, profile_id::2,
-           sampling_frequency_id::4, _priv_bit::1, channel_config_id::3, _bitrate::4,
-           frame_length::13, _buffer_fullness::11, aac_frames_cnt::2, rest::binary>> = data,
+           sampling_frequency_id::4, _priv_bit::1, channel_config_id::3, _originality::1,
+           _home::1, _copyright_id_bit::1, _copyright_id_start::1, frame_length::13,
+           _buffer_fullness::11, aac_frames_cnt::2, rest::binary>> = data,
          options
        )
        when sampling_frequency_id <= 12 do
@@ -144,9 +145,9 @@ defmodule Membrane.AAC.Parser.Helper do
       # home
       0::1,
       # copyright identification bit
-      1::1,
+      0::1,
       # copyright identification start
-      1::1,
+      0::1,
       # aac frame length
       frame_length::13,
       # adts buffer fullness (signalling VBR - most decoders don't care anyway)

--- a/lib/membrane/aac/parser/helper.ex
+++ b/lib/membrane/aac/parser/helper.ex
@@ -49,7 +49,7 @@ defmodule Membrane.AAC.Parser.Helper do
     do: {:ok, {:halt, {data, timestamp}}}
 
   defp parse_header(
-         <<0xFFF::12, _version::1, 0::2, protection_absent::1, profile_id::2,
+         <<0xFFF::12, _id::1, _layer::2, protection_absent::1, profile_id::2,
            sampling_frequency_id::4, _priv_bit::1, channel_config_id::3, _originality::1,
            _home::1, _copyright_id_bit::1, _copyright_id_start::1, frame_length::13,
            _buffer_fullness::11, aac_frames_cnt::2, rest::binary>> = data,


### PR DESCRIPTION
This PR: 
* Makes the input parser's stream format more precise. 
* Add raising of an exception once incompatible `in_encapsulation` and `out_encapsulation` params are provided for the incoming `Membrane.RemoteStream`
* Rename the fields in the ADST header parsing to the proper one.
*  Set the copyright id bit and copyright id start to 0 during the header creation