### PR TITLE
Bump to v0.17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The package can be installed by adding `membrane_aac_plugin` to your list of dep
 ```elixir
 def deps do
   [
-    {:membrane_aac_plugin, "~> 0.16.1"}
+    {:membrane_aac_plugin, "~> 0.17.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.AAC.MixProject do
   use Mix.Project
 
-  @version "0.16.1"
+  @version "0.17.0"
   @github_url "https://github.com/membraneframework/membrane_aac_plugin"
 
   def project do


### PR DESCRIPTION
I am bumping a minor since https://github.com/membraneframework/membrane_aac_plugin/pull/31 breaks the API (the buffers' PTS used to be `Ratio.t()` and now are rounded to the integer)