### PR TITLE
Tolerate DecoderConfigDescriptor with cleared reserved bit in esds parser

### DIFF
--- a/lib/membrane/aac/parser/esds.ex
+++ b/lib/membrane/aac/parser/esds.ex
@@ -45,7 +45,8 @@ defmodule Membrane.AAC.Parser.Esds do
     {section_3, <<>>} = unpack_esds_section(esds, 3)
 
     <<_elementary_stream_id::16, stream_dependence_flag::1, url_flag::1, ocr_stream_flag::1,
-      _stream_priority::5, rest::binary>> =
+      _stream_priority::5,
+      rest::binary>> =
       section_3
 
     rest =
@@ -72,10 +73,13 @@ defmodule Membrane.AAC.Parser.Esds do
     # 5 = audio
     stream_type = 5
     upstream_flag = 0
-    reserved_flag_set_to_1 = 1
 
-    <<^object_type_id, ^stream_type::6, ^upstream_flag::1, ^reserved_flag_set_to_1::1,
-      _buffer_size::24, _max_bit_rate::32, _avg_bit_rate::32, esds_section_5::binary>> = section_4
+    # The trailing bit of this byte is "reserved" and ISO/IEC 14496-1 mandates
+    # it be set to 1. Some encoders leave it cleared (emitting 0x14 instead of
+    # 0x15), so we accept either value rather than crashing on otherwise-valid
+    # streams.
+    <<^object_type_id, ^stream_type::6, ^upstream_flag::1, _reserved_flag::1, _buffer_size::24,
+      _max_bit_rate::32, _avg_bit_rate::32, esds_section_5::binary>> = section_4
 
     {section_5, <<>>} = unpack_esds_section(esds_section_5, 5)
 

--- a/lib/membrane/aac/parser/esds.ex
+++ b/lib/membrane/aac/parser/esds.ex
@@ -44,10 +44,8 @@ defmodule Membrane.AAC.Parser.Esds do
   def parse_esds(esds) do
     {section_3, <<>>} = unpack_esds_section(esds, 3)
 
-    <<_elementary_stream_id::16, stream_dependence_flag::1, url_flag::1, ocr_stream_flag::1,
-      _stream_priority::5,
-      rest::binary>> =
-      section_3
+    <<_elementary_stream_id::16, flags::binary-size(1), rest::binary>> = section_3
+    <<stream_dependence_flag::1, url_flag::1, ocr_stream_flag::1, _stream_priority::5>> = flags
 
     rest =
       rest

--- a/test/membrane/aac/parser/esds_test.exs
+++ b/test/membrane/aac/parser/esds_test.exs
@@ -1,0 +1,40 @@
+defmodule Membrane.AAC.Parser.EsdsTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: true
+
+  alias Membrane.AAC
+  alias Membrane.AAC.Parser.Esds
+
+  describe "parse_esds/1" do
+    test "tolerates a DecoderConfigDescriptor whose reserved bit is 0" do
+      # Real esds captured from an MP4 whose encoder leaves the
+      # DecoderConfigDescriptor "reserved" bit cleared: the second byte is
+      # 0x14 (stream_type 5, upstream 0, reserved 0) instead of the
+      # spec-mandated 0x15. ISO/IEC 14496-1 says the bit "should" be 1, but
+      # many encoders emit 0 and a parser must not crash on otherwise-valid
+      # streams.
+      section_4 =
+        <<64, 0x14, 0, 24, 0, 0, 1, 244, 0, 0, 1, 244, 0, 5, 128, 128, 128, 2, 0x11, 0x90>>
+
+      section_4_wrapped = <<4, 128, 128, 128, byte_size(section_4), section_4::binary>>
+      section_6 = <<6, 128, 128, 128, 1, 2>>
+      section_3_payload = <<1::16, 0, section_4_wrapped::binary, section_6::binary>>
+      esds = <<3, 128, 128, 128, byte_size(section_3_payload), section_3_payload::binary>>
+
+      assert %AAC{profile: :LC, sample_rate: 48_000, channels: 2} = Esds.parse_esds(esds)
+    end
+
+    test "parses a DecoderConfigDescriptor whose reserved bit is the conformant 1" do
+      section_4 =
+        <<64, 0x15, 0, 24, 0, 0, 1, 244, 0, 0, 1, 244, 0, 5, 128, 128, 128, 2, 0x11, 0x90>>
+
+      section_4_wrapped = <<4, 128, 128, 128, byte_size(section_4), section_4::binary>>
+      section_6 = <<6, 128, 128, 128, 1, 2>>
+      section_3_payload = <<1::16, 0, section_4_wrapped::binary, section_6::binary>>
+      esds = <<3, 128, 128, 128, byte_size(section_3_payload), section_3_payload::binary>>
+
+      assert %AAC{profile: :LC, sample_rate: 48_000, channels: 2} = Esds.parse_esds(esds)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

`Membrane.AAC.Parser.Esds.parse_esds/1` pattern-matches the trailing **reserved** bit of the DecoderConfigDescriptor as a hard-coded `1`:

```elixir
reserved_flag_set_to_1 = 1
<<^object_type_id, ^stream_type::6, ^upstream_flag::1, ^reserved_flag_set_to_1::1, ...>> = section_4
```

ISO/IEC 14496-1 says that bit *should* be set, but a number of real-world encoders emit it as `0` — the byte is `0x14` instead of `0x15`. These streams are otherwise perfectly valid, yet parsing crashes with:

```
** (MatchError) no match of right hand side value:
   <<64, 20, 0, 24, 0, 0, 1, 244, 0, 0, 1, 244, 0, 5, 128, 128, 128, 2, 17, 144>>
   (membrane_aac_plugin) lib/membrane/aac/parser/esds.ex:78
```

Because the AAC parser element crashes, the whole Membrane pipeline goes down — e.g. an MP4 played back through Boombox fails entirely even though the video track is fine, just because of the audio track's esds.

## Fix

Relax the match to accept either value for the reserved bit, while keeping `object_type_id`, `stream_type` and `upstream_flag` strict. The reserved bit carries no information we use, so ignoring its value is safe and matches the leniency of other demuxers/players (ffmpeg, etc.).

## Tests

Adds direct unit tests for `parse_esds/1` covering both the cleared (`0x14`) and conformant (`0x15`) reserved-bit cases. The cleared case reproduces a real esds captured from a failing MP4; before the fix it raised the exact `MatchError` above. Full suite passes (`mix test` — 10 tests, 0 failures).